### PR TITLE
assetIssue with memo option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules/
 package-lock.json
 /dist/
+/tests/test-config.json

--- a/lib/bitshares.js
+++ b/lib/bitshares.js
@@ -316,14 +316,14 @@ export default class BitShares {
     return this.sendTransaction("transfer",operation);
   }
 
-    async assetIssue(toName, assetSymbol, amount) {
+    async assetIssue(toName, assetSymbol, amount, memo) {
         await this.initPromise;
 
         let asset = await BitShares.assets[assetSymbol],
             intAmount = Math.floor(amount * 10 ** asset.precision);
 
-        if (intAmount == 0)
-            throw new Error("Amount equal 0!")
+        if (intAmount === 0)
+            throw new Error("Amount equal 0!");
 
         let operation = {
             fee: this.feeAsset.toParam(),
@@ -331,6 +331,9 @@ export default class BitShares {
             asset_to_issue: asset.toParam(intAmount),
             issue_to_account: (await BitShares.accounts[toName]).id
         };
+
+        if (memo)
+            operation.memo = (typeof memo === "string") ? (await this.memo(toName, memo)) : memo;
 
         return this.sendTransaction("asset_issue",operation);
     }
@@ -344,8 +347,8 @@ export default class BitShares {
         let asset = await BitShares.assets[assetSymbol],
             intAmount = Math.floor(amount * 10 ** asset.precision);
 
-        if (intAmount == 0)
-            throw new Error("Amount equal 0!")
+        if (intAmount === 0)
+            throw new Error("Amount equal 0!");
 
         let operation = {
             fee: this.feeAsset.toParam(),

--- a/tests/sample-test-config.json
+++ b/tests/sample-test-config.json
@@ -1,0 +1,6 @@
+{
+  "KEY": "5..private_key",
+  "SENDER": "..sender_name",
+  "ASSET": "..asset_name",
+  "MEMO": "test_message_memo"
+}

--- a/tests/test-AssetIssueWithMemo.js
+++ b/tests/test-AssetIssueWithMemo.js
@@ -1,0 +1,20 @@
+const BitShares =  require("../index.js");
+const fs = require("fs");
+const nconf = require("nconf");
+nconf.argv().file("test-config.json");
+
+let TEST_KEY = nconf.get("KEY");
+let TEST_SENDER = nconf.get("SENDER");
+let TEST_ASSET = nconf.get("ASSET");
+let TEST_RECIPIENT = 'techn0log';
+let TEST_MEMO = nconf.get("MEMO");
+let TEST_AMOUNT = 10.51;
+
+BitShares.init("wss://bitshares.openledger.info/ws");
+BitShares.subscribe('connected', test);
+
+async function test() {
+    let bot = new BitShares(TEST_SENDER, TEST_KEY);
+    bot.setMemoKey(TEST_KEY);
+    console.log(await bot.assetIssue(TEST_RECIPIENT, TEST_ASSET, TEST_AMOUNT, TEST_MEMO));
+}


### PR DESCRIPTION
assetIssue - added memo optional

example: 
```js
async function TestIssueAssetWithMemo() {
    let bot = new BitShares(SENDER, KEY);
    bot.setMemoKey(KEY);
    await bot.assetIssue(RECIPIENT, ASSET, AMOUNT, TEST_MEMO);
}
```