### PR TITLE
Cannot access 'restriction' before initialization

### DIFF
--- a/packages/serializer/src/operations.js
+++ b/packages/serializer/src/operations.js
@@ -1401,8 +1401,8 @@ export const restriction = new Serializer("restriction", {
     set(protocol_id_type("vesting_balance")),
     set(protocol_id_type("worker")),
     set(protocol_id_type("balance")),
-    array(restriction),
-    array(array(restriction)),
+//    array(restriction),
+//    array(array(restriction)),
     // fixme: pair<int64_t,std_vector<graphene::protocol::restriction>>
   ]),
   extensions: set(future_extensions),

--- a/packages/serializer/src/operations.js
+++ b/packages/serializer/src/operations.js
@@ -1400,10 +1400,10 @@ export const restriction = new Serializer("restriction", {
     set(protocol_id_type("withdraw_permission")),
     set(protocol_id_type("vesting_balance")),
     set(protocol_id_type("worker")),
-    set(protocol_id_type("balance")),
+    set(protocol_id_type("balance"))
 //    array(restriction),
 //    array(array(restriction)),
-    // fixme: pair<int64_t,std_vector<graphene::protocol::restriction>>
+// fixme: pair<int64_t,std_vector<graphene::protocol::restriction>>
   ]),
   extensions: set(future_extensions),
 });


### PR DESCRIPTION
These two lines used for restriction operation *new operation* are causing the script not to run any other operation; perhaps it's the same case with bitsharesjs, will keep it commented until it's fixed.